### PR TITLE
Ignore __pycache__ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.project
 /.pydevproject
+**/__pycache__


### PR DESCRIPTION
I'm versioning my homeassistant config in git with `custom_components` defined as a submodule (it is my only custom component):

```
[submodule "custom_components"]
        path = custom_components
        url = https://github.com/pdecat/homeassistant-zigate.git
```

At runtime, `__pycache__` directories are generated there so ignoring them helps a lot.