### PR TITLE
Additional HA events from zigate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.project
 /.pydevproject
+__pycache__

--- a/zigate/__init__.py
+++ b/zigate/__init__.py
@@ -218,9 +218,14 @@ def setup(hass, config):
         for platform in SUPPORTED_PLATFORMS:
             load_platform(hass, platform, DOMAIN, {}, config)
 
+        hass.bus.fire('zigate.started')
+
+
     def stop_zigate(service_event):
         myzigate.save_state()
         myzigate.close()
+
+        hass.bus.fire('zigate.stopped')
 
     def refresh_devices_list(service):
         myzigate.get_devices_list()

--- a/zigate/__init__.py
+++ b/zigate/__init__.py
@@ -164,6 +164,12 @@ def setup(hass, config):
             if entity.hass:
                 entity.schedule_update_ha_state()
 
+        event_data = attribute.copy()
+        event_data['ieee'] = device.ieee
+        event_data['device_type'] = device.get_property_value('type')
+        event_data['entity_id'] = entity.entity_id
+        hass.bus.fire('zigate.update_attribute', event_data)
+
     zigate.dispatcher.connect(attribute_updated,
                               zigate.ZIGATE_ATTRIBUTE_UPDATED, weak=False)
 


### PR DESCRIPTION
Event for starting and stoping zigate it's needed to delay homekit start (stop is for symmetry).

Event for attribute change this is required for example to create automation connected with aqara wireless wall swich for example to support two switch like stairs switch (wall switch + wireless switch).  Wireless switch is recognize as binary sensor and click in it cause two events one by one and sometimes binary sensor doesn't recognize state change, so no event from sensor :-/. With zigate attribute change event there is no problem to have this setup work, because automation base on zigate 'on' event and doesn't relay on binary sensor event which sometimes missing (race condition).