### PR TITLE
Improve light polling

### DIFF
--- a/zigate/light.py
+++ b/zigate/light.py
@@ -109,7 +109,8 @@ class ZiGateLight(Light):
         return self._device.assumed_state
 
     def update(self):
-        self._device.refresh_device()
+        self.hass.data[ZIGATE_DOMAIN].read_attribute_request(self._device.addr, self._endpoint, 6, 0)
+        #self._device.refresh_device()
 
     @property
     def name(self) -> str:

--- a/zigate/light.py
+++ b/zigate/light.py
@@ -110,7 +110,6 @@ class ZiGateLight(Light):
 
     def update(self):
         self.hass.data[ZIGATE_DOMAIN].read_attribute_request(self._device.addr, self._endpoint, 6, 0)
-        #self._device.refresh_device()
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
Hi @doudz 

I have some performance problem with some light that does not refresh their state (some phillips hue with firmware upgrade) So i forced "assumed_state":"true" in zigate.json to (badly) fix the problem, but i have some performance problem since HA refresh all readable attributes when polling

What do you think of this change to improve performance when refreshing lights ? 
Does it break somethings ? Full refresh can still be done on zigate entity device.

