### PR TITLE
Fix #93: home-assistant 0.104.0 removed generated groups

### DIFF
--- a/custom_components/zigate/__init__.py
+++ b/custom_components/zigate/__init__.py
@@ -36,7 +36,6 @@ DATA_ZIGATE_ATTRS = 'zigate_attributes'
 ADDR = 'addr'
 IEEE = 'ieee'
 
-GROUP_NAME_ALL_ZIGATE = 'all zigate'
 ENTITY_ID_ALL_ZIGATE = GROUP_ENTITY_ID_FORMAT.format('all_zigate')
 
 SUPPORTED_PLATFORMS = ('sensor',
@@ -285,7 +284,7 @@ def setup(hass, config):
     hass.data[DATA_ZIGATE_DEVICES] = {}
     hass.data[DATA_ZIGATE_ATTRS] = {}
 
-    component = EntityComponent(_LOGGER, DOMAIN, hass, scan_interval, GROUP_NAME_ALL_ZIGATE)
+    component = EntityComponent(_LOGGER, DOMAIN, hass, scan_interval)
     component.setup(config)
     entity = ZiGateComponentEntity(myzigate)
     hass.data[DATA_ZIGATE_DEVICES]['zigate'] = entity


### PR DESCRIPTION
This PR fixes #93 with HA 0.104.0+.

Note: this should not break compatibility with older HA versions as `group_name` had a default value.

https://github.com/home-assistant/home-assistant/blob/0.103.6/homeassistant/helpers/entity_component.py#L66

https://github.com/home-assistant/home-assistant/blob/0.104.0/homeassistant/helpers/entity_component.py#L64