### PR TITLE
Remove attributes from old States UI

### DIFF
--- a/packages/zigate.yaml
+++ b/packages/zigate.yaml
@@ -19,28 +19,23 @@ homeassistant:
     group.zigate_command:
       <<: *customize
       friendly_name: "ZiGate Commands"
-      control: hidden
       
     group.all_zigate:
       <<: *customize
       friendly_name: "ZiGate"
-      control: hidden
       hidden: false
 
 group:
   zigate_view:
-    view: yes
     entities:
       - group.all_zigate
       - group.zigate_command
     
   zigate_command:
-    control: hidden
     entities:
       - input_boolean.zigate_permit_join
       
   zigate_entities:
-    control: hidden
 
 input_boolean:
   zigate_permit_join:


### PR DESCRIPTION
Starting from 0.107, the `view` and `control` options in groups have been removed, causing an invalid configuration: https://www.home-assistant.io/blog/2020/03/18/release-107/#breaking-changes