### PR TITLE
move translations to new folder

### DIFF
--- a/custom_components/zigate/translations/en.json
+++ b/custom_components/zigate/translations/en.json
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "title": "ZiGate",
+    "step": {
+      "user": {
+        "title": "ZiGate",
+        "data": {
+          "port": "USB Device Path"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Unable to connect to ZiGate."
+    },
+    "abort": {
+      "single_instance_allowed": "Only a single configuration of ZiGate is allowed."
+    }
+  }
+}

--- a/custom_components/zigate/translations/fr.json
+++ b/custom_components/zigate/translations/fr.json
@@ -1,0 +1,19 @@
+{
+  "config": {
+    "title": "ZiGate",
+    "step": {
+      "user": {
+        "title": "ZiGate",
+        "data": {
+          "port": "Port USB"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Impossible de se connecter à ZiGate."
+    },
+    "abort": {
+      "single_instance_allowed": "Une seule configuration de ZiGate est autorisée."
+    }
+  }
+}


### PR DESCRIPTION
Fixes this warning, which will become an error in home assistant 0.111

`WARNING (MainThread) [homeassistant.helpers.translation] zigate: the '.translations' directory has been moved, the new name is 'translations', starting with Home Assistant 0.111 your translations will no longer load if you do not move/rename this`