### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -26,7 +26,7 @@ custom_components/
     ├── cover.py
     └── climate.py
 ```
-
+- restart your Home Assistant, so that it installs requirements
 - adapt your configuration.yaml
 
 To pair a new device, go in developer/services and call the 'zigate.permit\_join' service.


### PR DESCRIPTION
Added a step to installation instruction.

As a novice with home assistant I spent some time figuring it out.

It is crucial not to include `zigate` component in main config without python `zigate` module installed. And it seems that Home Assistant only installs custom components requirements on reboot.