### PR TITLE
Update manifest.json

### DIFF
--- a/custom_components/zigate/manifest.json
+++ b/custom_components/zigate/manifest.json
@@ -5,5 +5,6 @@
   "issue_tracker": "https://github.com/doudz/homeassistant-zigate/issues",
   "dependencies": ["persistent_notification"],
   "codeowners": ["doudz"],
-  "requirements": ["zigate==0.40.11"]
+  "requirements": ["zigate==0.40.11"],
+  "version": "20.11.28"
 }


### PR DESCRIPTION
The version key is required from Home Assistant version 2021.6 : https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes/#versions
So I added version with the date of the last official commit of the plugin